### PR TITLE
feat: add file mode to local file fix

### DIFF
--- a/doc/f/local_file.md
+++ b/doc/f/local_file.md
@@ -7,7 +7,7 @@ The `local_file` fix block in the `grept` tool is used to write a specified cont
 - `rule_ids`: The ID list of the rules this fix is associated with. Any rule check failure would trigger this fix.
 - `paths`: A list of file paths where the content should be written.
 - `content`: The content to be written to the files.
-- `mode`: (Optional) The file mode to be set on the files. Defaults to `0644`.
+- `mode`: (Optional) The mode to set if creating a new file. Defaults to `0644`.
 
 ## Exported Attributes
 

--- a/doc/f/local_file.md
+++ b/doc/f/local_file.md
@@ -7,6 +7,7 @@ The `local_file` fix block in the `grept` tool is used to write a specified cont
 - `rule_ids`: The ID list of the rules this fix is associated with. Any rule check failure would trigger this fix.
 - `paths`: A list of file paths where the content should be written.
 - `content`: The content to be written to the files.
+- `mode`: (Optional) The file mode to be set on the files. Defaults to `0644`.
 
 ## Exported Attributes
 

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -811,7 +810,4 @@ func (s *configSuite) TestApplyPlan_file_fix_with_null_mode() {
 	content1, err := afero.ReadFile(FsFactory(), "/example/testfile")
 	assert.NoError(t, err)
 	assert.Equal(t, "hello", string(content1))
-
-	finfo, err := s.testBase.fs.Stat("/example/testfile")
-	assert.Equal(t, fs.FileMode(0644), finfo.Mode())
 }

--- a/pkg/data_http.go
+++ b/pkg/data_http.go
@@ -3,17 +3,18 @@ package pkg
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/emirpasic/gods/sets/hashset"
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/zclconf/go-cty/cty"
-	"golang.org/x/net/http/httpproxy"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/emirpasic/gods/sets/hashset"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/net/http/httpproxy"
 )
 
 var _ Data = &HttpDatasource{}

--- a/pkg/fix_local_file.go
+++ b/pkg/fix_local_file.go
@@ -13,9 +13,9 @@ var _ Fix = &LocalFileFix{}
 type LocalFileFix struct {
 	*BaseBlock
 	*BaseFix
-	Paths   []string    `json:"paths" hcl:"paths"`
-	Content string      `json:"content" hcl:"content"`
-	Mode    fs.FileMode `json:"mode" hcl:"mode,optional"`
+	Paths   []string     `json:"paths" hcl:"paths"`
+	Content string       `json:"content" hcl:"content"`
+	Mode    *fs.FileMode `json:"mode" hcl:"mode,optional"`
 }
 
 func (lf *LocalFileFix) Values() map[string]cty.Value {
@@ -32,11 +32,12 @@ func (lf *LocalFileFix) Type() string {
 
 func (lf *LocalFileFix) Apply() error {
 	var err error
-	if lf.Mode == 0 {
-		lf.Mode = 0644
+	var defmode = fs.FileMode(0644)
+	if lf.Mode == nil {
+		lf.Mode = &defmode
 	}
 	for _, path := range lf.Paths {
-		writeErr := afero.WriteFile(FsFactory(), path, []byte(lf.Content), lf.Mode)
+		writeErr := afero.WriteFile(FsFactory(), path, []byte(lf.Content), *lf.Mode)
 		if writeErr != nil {
 			err = multierror.Append(err, writeErr)
 		}

--- a/pkg/fix_local_file.go
+++ b/pkg/fix_local_file.go
@@ -17,7 +17,7 @@ type LocalFileFix struct {
 	*BaseFix
 	Paths   []string `json:"paths" hcl:"paths"`
 	Content string   `json:"content" hcl:"content"`
-	Mode    *string  `json:"mode" hcl:"mode,optional"`
+	Mode    *uint32  `json:"mode" hcl:"mode,optional"`
 }
 
 func (lf *LocalFileFix) Values() map[string]cty.Value {
@@ -36,7 +36,7 @@ func (lf *LocalFileFix) Apply() error {
 	var err error
 	var mode uint64 = 420 // 0644
 	if lf.Mode != nil {
-		mode, err = strconv.ParseUint(*lf.Mode, 8, 32)
+		mode, err = strconv.ParseUint(strconv.Itoa(int(*lf.Mode)), 8, 32)
 		if err != nil {
 			return fmt.Errorf("invalid file mode: %w", err)
 		}

--- a/pkg/fix_local_file.go
+++ b/pkg/fix_local_file.go
@@ -34,14 +34,15 @@ func (lf *LocalFileFix) Type() string {
 
 func (lf *LocalFileFix) Apply() error {
 	var err error
-	var mode uint64 = 420 // 0644
+	var filemode = fs.FileMode(0644)
 	if lf.Mode != nil {
-		mode, err = strconv.ParseUint(strconv.Itoa(int(*lf.Mode)), 8, 32)
+		mode, err := strconv.ParseUint(strconv.Itoa(int(*lf.Mode)), 8, 32)
 		if err != nil {
 			return fmt.Errorf("invalid file mode: %w", err)
 		}
+		filemode = fs.FileMode(mode)
 	}
-	filemode := fs.FileMode(mode)
+
 	for _, path := range lf.Paths {
 		writeErr := afero.WriteFile(FsFactory(), path, []byte(lf.Content), filemode)
 		if writeErr != nil {

--- a/pkg/fix_local_file.go
+++ b/pkg/fix_local_file.go
@@ -15,7 +15,7 @@ type LocalFileFix struct {
 	*BaseFix
 	Paths   []string    `json:"paths" hcl:"paths"`
 	Content string      `json:"content" hcl:"content"`
-	Mode    fs.FileMode `json:"mode" hcl:"mode"`
+	Mode    fs.FileMode `json:"mode" hcl:"mode,optional"`
 }
 
 func (lf *LocalFileFix) Values() map[string]cty.Value {

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -118,12 +118,12 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasCustomMode() {
 	fs := s.fs
 	t := s.T()
 	path := "/file1.txt"
-	modestr := "0755"
+	mode := uint32(755)
 	fix := &LocalFileFix{
 		BaseBlock: &BaseBlock{},
 		Paths:     []string{path},
 		Content:   "Hello, world!",
-		Mode:      &modestr,
+		Mode:      &mode,
 	}
 
 	// Create the file first

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -113,3 +113,25 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasDefaultMode0644() {
 	assert.NoError(t, err)
 	assert.Equal(t, finfo.Mode(), iofs.FileMode(0644))
 }
+
+func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasCustomMode() {
+	fs := s.fs
+	t := s.T()
+	path := "/file1.txt"
+	mode := iofs.FileMode(0755)
+	fix := &LocalFileFix{
+		BaseBlock: &BaseBlock{},
+		Paths:     []string{path},
+		Content:   "Hello, world!",
+		Mode:      &mode,
+	}
+
+	// Create the file first
+	err := fix.Apply()
+	assert.NoError(t, err)
+
+	// Check default mode 0644
+	finfo, err := fs.Stat(path)
+	assert.NoError(t, err)
+	assert.Equal(t, finfo.Mode(), mode)
+}

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -118,12 +118,12 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasCustomMode() {
 	fs := s.fs
 	t := s.T()
 	path := "/file1.txt"
-	mode := iofs.FileMode(0755)
+	modestr := "0755"
 	fix := &LocalFileFix{
 		BaseBlock: &BaseBlock{},
 		Paths:     []string{path},
 		Content:   "Hello, world!",
-		Mode:      &mode,
+		Mode:      &modestr,
 	}
 
 	// Create the file first
@@ -133,5 +133,5 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasCustomMode() {
 	// Check custom mode
 	finfo, err := fs.Stat(path)
 	assert.NoError(t, err)
-	assert.Equal(t, finfo.Mode(), mode)
+	assert.Equal(t, finfo.Mode(), iofs.FileMode(0755))
 }

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -1,8 +1,10 @@
 package pkg
 
 import (
-	"github.com/stretchr/testify/suite"
+	iofs "io/fs"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -90,4 +92,45 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileInSubFolder() {
 	content, err := afero.ReadFile(fs, path)
 	assert.NoError(t, err)
 	assert.Equal(t, fix.Content, string(content))
+}
+
+func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasDefaultMode0644() {
+	fs := s.fs
+	t := s.T()
+	path := "/file1.txt"
+	fix := &LocalFileFix{
+		BaseBlock: &BaseBlock{},
+		Paths:     []string{path},
+		Content:   "Hello, world!",
+	}
+
+	// Create the file first
+	err := fix.Apply()
+	assert.NoError(t, err)
+
+	// Check default mode 0644
+	finfo, err := fs.Stat(path)
+	assert.NoError(t, err)
+	assert.Equal(t, finfo.Mode(), iofs.FileMode(0644))
+}
+
+func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasCustomMode() {
+	fs := s.fs
+	t := s.T()
+	path := "/file1.txt"
+	fix := &LocalFileFix{
+		BaseBlock: &BaseBlock{},
+		Paths:     []string{path},
+		Content:   "Hello, world!",
+		Mode:      0755,
+	}
+
+	// Create the file first
+	err := fix.Apply()
+	assert.NoError(t, err)
+
+	// Check custom mode
+	finfo, err := fs.Stat(path)
+	assert.NoError(t, err)
+	assert.Equal(t, finfo.Mode(), fix.Mode)
 }

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -135,3 +135,24 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasCustomMode() {
 	assert.NoError(t, err)
 	assert.Equal(t, finfo.Mode(), iofs.FileMode(0755))
 }
+
+func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasNilMode() {
+	fs := s.fs
+	t := s.T()
+	path := "/file1.txt"
+	fix := &LocalFileFix{
+		BaseBlock: &BaseBlock{},
+		Paths:     []string{path},
+		Content:   "Hello, world!",
+		Mode:      nil,
+	}
+
+	// Create the file first
+	err := fix.Apply()
+	assert.NoError(t, err)
+
+	// Check custom mode
+	finfo, err := fs.Stat(path)
+	assert.NoError(t, err)
+	assert.Equal(t, finfo.Mode(), iofs.FileMode(0644))
+}

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -130,7 +130,7 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasCustomMode() {
 	err := fix.Apply()
 	assert.NoError(t, err)
 
-	// Check default mode 0644
+	// Check custom mode
 	finfo, err := fs.Stat(path)
 	assert.NoError(t, err)
 	assert.Equal(t, finfo.Mode(), mode)

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -113,24 +113,3 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasDefaultMode0644() {
 	assert.NoError(t, err)
 	assert.Equal(t, finfo.Mode(), iofs.FileMode(0644))
 }
-
-func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileHasCustomMode() {
-	fs := s.fs
-	t := s.T()
-	path := "/file1.txt"
-	fix := &LocalFileFix{
-		BaseBlock: &BaseBlock{},
-		Paths:     []string{path},
-		Content:   "Hello, world!",
-		Mode:      0755,
-	}
-
-	// Create the file first
-	err := fix.Apply()
-	assert.NoError(t, err)
-
-	// Check custom mode
-	finfo, err := fs.Stat(path)
-	assert.NoError(t, err)
-	assert.Equal(t, finfo.Mode(), fix.Mode)
-}


### PR DESCRIPTION
This pull request adds the ability to set the file mode for the local_file fix. The most important changes include adding new test cases to verify the behavior of the `Apply` method in the `LocalFileFix` struct, modifying the `Apply` method to support custom file modes, and adding documentation for the `local_file` fix block.

Behavior improvements:

* [`pkg/fix_local_file_test.go`](diffhunk://#diff-8a074afb2b4a2d80533f9d6f900991210905f2b18fd18c6d464cd2262f976ae3R96-R158): Added new test cases to verify the behavior of the `Apply` method in the `LocalFileFix` struct. [[1]](diffhunk://#diff-8a074afb2b4a2d80533f9d6f900991210905f2b18fd18c6d464cd2262f976ae3R96-R158) [[2]](diffhunk://#diff-8a074afb2b4a2d80533f9d6f900991210905f2b18fd18c6d464cd2262f976ae3L4-R8)
* [`pkg/fix_local_file.go`](diffhunk://#diff-e659ab099e1e4aacda5f33e6ed3d5447fac449f10f0b169ad425dcbeefd5dbc4R4-R7): Modified the `Apply` method of the `LocalFileFix` struct to support custom file modes. Added a `Mode` field to the struct and import statements for the `fmt`, `io/fs`, and `strconv` packages. [[1]](diffhunk://#diff-e659ab099e1e4aacda5f33e6ed3d5447fac449f10f0b169ad425dcbeefd5dbc4R4-R7) [[2]](diffhunk://#diff-e659ab099e1e4aacda5f33e6ed3d5447fac449f10f0b169ad425dcbeefd5dbc4R20-R27) [[3]](diffhunk://#diff-e659ab099e1e4aacda5f33e6ed3d5447fac449f10f0b169ad425dcbeefd5dbc4R37-R47)
* [`pkg/config_test.go`](diffhunk://#diff-38b0a49b2804557a19611060a29d32d284cfa4b09c6c067319c3b302ad9d51bbR7-L15): Added a new test case to verify the behavior of applying a plan with a `local_file` fix block with a `null` mode. [[1]](diffhunk://#diff-38b0a49b2804557a19611060a29d32d284cfa4b09c6c067319c3b302ad9d51bbR7-L15) [[2]](diffhunk://#diff-38b0a49b2804557a19611060a29d32d284cfa4b09c6c067319c3b302ad9d51bbR781-R813)

Documentation improvements:

* [`doc/f/local_file.md`](diffhunk://#diff-04ee2c2ebd481c124f375fb3331e48759dca52e6a15cabc75bedd22e632a05b5R10): Added documentation for the optional `mode` attribute in the `local_file` fix block.
* [`pkg/data_http.go`](diffhunk://#diff-2d6f406b637788ac7777fbcd8c52947f05fa90e07387f8379427a50532a75384L6-R17): Added import statements for required packages.