### PR TITLE
Use `go-defaults` to set default value for file mode, use `validate` library to validate all blocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/lonegunmanb/go-yaml-edit v0.0.0-20231115083743-85302adf634b
 	github.com/lonegunmanb/hclfuncs v0.4.1
 	github.com/lonegunmanb/yaml-jsonpointer v0.1.2-0.20231115082754-71ac0a5bbbd2
-	github.com/mcuadros/go-defaults v1.2.0
+	github.com/mcuadros/go-defaults v1.3.0
 	github.com/peterh/liner v1.2.2
 	github.com/prashantv/gostub v1.1.0
 	github.com/spf13/afero v1.11.0
@@ -96,3 +96,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/mcuadros/go-defaults v1.3.0 => github.com/lonegunmanb/go-defaults v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 codeberg.org/6543/go-yaml2json v1.0.0 h1:heGqo9VEi7gY2yNqjj7X4ADs5nzlFIbGsJtgYDLrnig=
 codeberg.org/6543/go-yaml2json v1.0.0/go.mod h1:mz61q14LWF4ZABrgMEDMmk3t9dPi6zgR1uBh2VKV2RQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -196,6 +198,8 @@ github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
 github.com/lonegunmanb/atomatt-yaml v0.0.0-20231115063413-65f675868d34 h1:k/TmToj7wP7k6Ul6bh4I9anc+y39+wVYRqjOVdAOnbQ=
 github.com/lonegunmanb/atomatt-yaml v0.0.0-20231115063413-65f675868d34/go.mod h1:VIId/O/ib34Xhk/gUq3Wi/NBGSo8ArxVLurqhBInv1c=
+github.com/lonegunmanb/go-defaults v1.3.0 h1:Ta5uZW54yWu2smdEZ3FrcgZcWIWvm/ppVFy0b1ibLI4=
+github.com/lonegunmanb/go-defaults v1.3.0/go.mod h1:0xAP3y7xIeYvZRoC51utMuERLFWbTNdghNH6/FH/lFY=
 github.com/lonegunmanb/go-yaml-edit v0.0.0-20231115083743-85302adf634b h1:iq8qR7E7mpIUs9n3TBxdFceYTfpsEdXcOaUXfxEW6e0=
 github.com/lonegunmanb/go-yaml-edit v0.0.0-20231115083743-85302adf634b/go.mod h1:uvga3hKd6b8WDuxlf7sgaxP0jUN5fdYBfCGhWAj75yo=
 github.com/lonegunmanb/hclfuncs v0.4.1 h1:z2ieMu+vCwIbT3K1MVVf6ac0coXi5XYjlIT/8CuL9rE=
@@ -225,8 +229,6 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mcuadros/go-defaults v1.2.0 h1:FODb8WSf0uGaY8elWJAkoLL0Ri6AlZ1bFlenk56oZtc=
-github.com/mcuadros/go-defaults v1.2.0/go.mod h1:WEZtHEVIGYVDqkKSWBdWKUVdRyKlMfulPaGDWIVeCWY=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/pkg/block.go
+++ b/pkg/block.go
@@ -41,7 +41,6 @@ var metaAttributeNames = hashset.New("for_each", "rule_ids")
 var metaNestedBlockNames = hashset.New("precondition")
 
 func decode(b block) error {
-	defaults.SetDefaults(b)
 	hb := b.HclBlock()
 	evalContext := b.EvalContext()
 	if decodeBase, ok := b.(DecodeBase); ok {
@@ -54,6 +53,7 @@ func decode(b block) error {
 	if diag.HasErrors() {
 		return diag
 	}
+	defaults.SetDefaults(b)
 	return nil
 }
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -227,6 +227,9 @@ func planBlock(b block) error {
 			return fmt.Errorf("%s.%s.%s is not valid: %s", b.BlockType(), b.Type(), b.Name(), err.Error())
 		}
 	}
+	if validateErr := validate.Struct(b); validateErr != nil {
+		return fmt.Errorf("%s.%s.%s is not valid: %s", b.BlockType(), b.Type(), b.Name(), validateErr.Error())
+	}
 	failedChecks, preConditionCheckError := b.PreConditionCheck(b.EvalContext())
 	if preConditionCheckError != nil {
 		return preConditionCheckError

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -597,7 +597,6 @@ func (s *configSuite) TestLocalBetweenDataAndRule() {
 }
 
 func (s *configSuite) TestForEach_ForEachBlockShouldBeExpanded() {
-	//s.T().Skip("for now")
 	hclConfig := `
 	locals {
 		items = ["item1", "item2", "item3"]

--- a/pkg/fix_local_file.go
+++ b/pkg/fix_local_file.go
@@ -2,11 +2,12 @@ package pkg
 
 import (
 	"fmt"
+	"io/fs"
+	"strconv"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
-	"io/fs"
-	"strconv"
 )
 
 var _ Fix = &LocalFileFix{}

--- a/pkg/fix_local_file.go
+++ b/pkg/fix_local_file.go
@@ -48,8 +48,8 @@ func (lf *LocalFileFix) Apply() error {
 	return err
 }
 
-func toDecimal(decimalMode fs.FileMode) (fs.FileMode, error) {
-	mode, err := strconv.ParseUint(strconv.Itoa(int(decimalMode)), 8, 32)
+func toDecimal(octalMode fs.FileMode) (fs.FileMode, error) {
+	mode, err := strconv.ParseUint(strconv.Itoa(int(octalMode)), 8, 32)
 	if err != nil {
 		return 0, fmt.Errorf("invalid file mode: %w", err)
 	}

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -5,10 +5,9 @@ import (
 	iofs "io/fs"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type localFileFixSuite struct {

--- a/pkg/fix_local_file_test.go
+++ b/pkg/fix_local_file_test.go
@@ -38,7 +38,7 @@ func (s *localFileFixSuite) TearDownSubTest() {
 func (s *localFileFixSuite) TestLocalFile_ApplyFix_CreateNewFile() {
 	fs := s.fs
 	t := s.T()
-	mode := iofs.FileMode(644)
+	mode := iofs.FileMode(0644)
 	fix := &LocalFileFix{
 		Paths:   []string{"/file1.txt"},
 		Content: "Hello, world!",
@@ -58,7 +58,7 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_OverwriteExistingFile() {
 	fs := s.fs
 	t := s.T()
 	path := "/file1.txt"
-	mode := iofs.FileMode(644)
+	mode := iofs.FileMode(0644)
 	fix := &LocalFileFix{
 		BaseBlock: &BaseBlock{},
 		Paths:     []string{path},
@@ -85,7 +85,7 @@ func (s *localFileFixSuite) TestLocalFile_ApplyFix_FileInSubFolder() {
 	fs := s.fs
 	t := s.T()
 	path := "/example/sub1/file1.txt"
-	mode := iofs.FileMode(644)
+	mode := iofs.FileMode(0644)
 	fix := &LocalFileFix{
 		BaseBlock: &BaseBlock{},
 		Paths:     []string{path},

--- a/pkg/validatable.go
+++ b/pkg/validatable.go
@@ -33,7 +33,7 @@ func validateFileMode(fl validator.FieldLevel) bool {
 	if err != nil {
 		return false
 	}
-	return mode >= 0 && uint32(mode) <= uint32(fs.ModePerm)
+	return uint32(mode) <= uint32(fs.ModePerm)
 }
 
 func validateAllStringInSlice(fl validator.FieldLevel) bool {

--- a/pkg/validatable.go
+++ b/pkg/validatable.go
@@ -1,11 +1,12 @@
 package pkg
 
 import (
-	"github.com/ahmetb/go-linq/v3"
-	"github.com/go-playground/validator/v10"
 	"io/fs"
 	"strconv"
 	"strings"
+
+	"github.com/ahmetb/go-linq/v3"
+	"github.com/go-playground/validator/v10"
 )
 
 var validate = validator.New(validator.WithRequiredStructEnabled())

--- a/pkg/validatable.go
+++ b/pkg/validatable.go
@@ -3,6 +3,8 @@ package pkg
 import (
 	"github.com/ahmetb/go-linq/v3"
 	"github.com/go-playground/validator/v10"
+	"io/fs"
+	"strconv"
 	"strings"
 )
 
@@ -13,10 +15,24 @@ func registerValidator() {
 	_ = validate.RegisterValidation("at_least_one_of", validateAtLeastOneOf)
 	_ = validate.RegisterValidation("required_with", validateRequiredWith)
 	_ = validate.RegisterValidation("all_string_in_slice", validateAllStringInSlice)
+	_ = validate.RegisterValidation("file_mode", validateFileMode)
 }
 
 type Validatable interface {
 	Validate() error
+}
+
+func validateFileMode(fl validator.FieldLevel) bool {
+	field := fl.Field().Interface()
+	num, ok := field.(fs.FileMode)
+	if !ok {
+		return false
+	}
+	mode, err := strconv.ParseUint(strconv.Itoa(int(num)), 8, 32)
+	if err != nil {
+		return false
+	}
+	return mode >= 0 && uint32(mode) <= uint32(fs.ModePerm)
 }
 
 func validateAllStringInSlice(fl validator.FieldLevel) bool {


### PR DESCRIPTION
[go-defaults](https://github.com/mcuadros/go-defaults) seems no longer maintained and due to this [issue](https://github.com/mcuadros/go-defaults/issues/14), it cannot set default value for pointer type field, I have to create [my personal fork](https://github.com/lonegunmanb/go-defaults) and merge this [pr](https://github.com/mcuadros/go-defaults/pull/22), then publish a new tag [`v1.3.0`](https://github.com/lonegunmanb/go-defaults/tree/v1.3.0) based on the `v1.2.0`.

This pr also use [`github.com/go-playground/validator`](https://github.com/go-playground/validator) to validate all blocks.