### PR TITLE
ci: remove macos-13 from runner matrix

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     permissions:
       # required for all workflows
       security-events: write


### PR DESCRIPTION
The macos-13 runner is no longer available/functional, causing CI checks to be cancelled. This PR removes it from the build matrix to unblock dependabot PRs.