### PR TITLE
ci: upgrade golangci-lint from v1.64.7 to v1.64.8

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         if: runner.os == 'Linux'
         run: |
-          docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.64.7 golangci-lint run -v --timeout=3600s
+          docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.64.8 golangci-lint run -v --timeout=3600s
       - name: Run Gosec Security Scanner
         uses: securego/gosec@136f6c00402b11775d4f4a45d5a21e2f6dd99db2 #v2.22.2
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Problem

The golangci-lint step in CI is failing because v1.64.7 was built with go1.24, which is lower than the project's targeted Go version (go1.25.0):

```text
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
```

## Fix

Upgrade the golangci-lint Docker image from v1.64.7 to v1.64.8, which is built with go1.25 and resolves this compatibility issue.

This should also unblock PR #142 (dependabot net upgrade).