### PR TITLE
ci: try upgrading golangci-lint to v2.10.1

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         if: runner.os == 'Linux'
         run: |
-          docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.64.8 golangci-lint run -v --timeout=3600s
+          docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.10.1 golangci-lint run -v
       - name: Run Gosec Security Scanner
         uses: securego/gosec@136f6c00402b11775d4f4a45d5a21e2f6dd99db2 #v2.22.2
         if: runner.os == 'Linux'

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -50,12 +50,12 @@ func applyFunc(auto *bool) func(*cobra.Command, []string) error {
 		}
 		config, err := pkg.BuildGreptConfig(pwd, configPath, c.Context(), varFlags)
 		if err != nil {
-			return fmt.Errorf("error parsing config: %s\n", err.Error())
+			return fmt.Errorf("error parsing config: %s", err.Error())
 		}
 
 		plan, err := pkg.RunGreptPlan(config)
 		if err != nil {
-			return fmt.Errorf("Error generating plan: %s\n", err.Error())
+			return fmt.Errorf("error generating plan: %s", err.Error())
 		}
 
 		if len(plan.FailedRules) == 0 {
@@ -77,7 +77,7 @@ func applyFunc(auto *bool) func(*cobra.Command, []string) error {
 		}
 		err = plan.Apply()
 		if err != nil {
-			return fmt.Errorf("error applying plan: %s\n", err.Error())
+			return fmt.Errorf("error applying plan: %s", err.Error())
 		}
 		fmt.Println("Plan applied successfully.")
 		return nil

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -42,12 +42,12 @@ func planFunc() func(*cobra.Command, []string) error {
 		}
 		config, err := pkg.BuildGreptConfig(pwd, configPath, c.Context(), varFlags)
 		if err != nil {
-			return fmt.Errorf("error parsing config: %+v\n", err)
+			return fmt.Errorf("error parsing config: %+v", err)
 		}
 
 		plan, err := pkg.RunGreptPlan(config)
 		if err != nil {
-			return fmt.Errorf("error generating plan: %s\n", err.Error())
+			return fmt.Errorf("error generating plan: %s", err.Error())
 		}
 
 		if len(plan.FailedRules) == 0 {

--- a/pkg/fix_copy_file_test.go
+++ b/pkg/fix_copy_file_test.go
@@ -16,7 +16,7 @@ func (s *copyFileFixSuite) SetupTest() {
 }
 
 func (s *copyFileFixSuite) TearDownTest() {
-	s.testBase.teardown()
+	s.teardown()
 }
 
 func TestCopyFileFixSuite(t *testing.T) {

--- a/pkg/fix_git_ignore_test.go
+++ b/pkg/fix_git_ignore_test.go
@@ -16,7 +16,7 @@ func (s *gitIgnoreFixSuite) SetupTest() {
 }
 
 func (s *gitIgnoreFixSuite) TearDownTest() {
-	s.testBase.teardown()
+	s.teardown()
 }
 
 func TestGitIgnoreFixSuite(t *testing.T) {

--- a/pkg/fix_local_shell.go
+++ b/pkg/fix_local_shell.go
@@ -97,13 +97,17 @@ func (l *LocalShellFix) downloadFile(url string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer out.Close()
+	defer func() {
+		_ = out.Close()
+	}()
 
 	resp, err := http.Get(url)
 	if err != nil {
 		return out.Name(), err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	_, err = io.Copy(out, resp.Body)
 	if err != nil {
@@ -126,7 +130,7 @@ func (l *LocalShellFix) createTmpFileForInlines(shebang string, inlines []string
 		_ = tmp.Close()
 	}()
 	writer := bufio.NewWriter(tmp)
-	_, err = writer.WriteString(fmt.Sprintf("#!%s\n", shebang))
+	_, err = fmt.Fprintf(writer, "#!%s\n", shebang)
 	if err != nil {
 		return tmp.Name(), err
 	}

--- a/pkg/fix_local_shell_test.go
+++ b/pkg/fix_local_shell_test.go
@@ -385,9 +385,7 @@ func (s *localExecFixSuite) TestLocalShellFix_ApplyFix_scriptWithUserAssignedEnv
 	defer func() {
 		_ = os.Remove(tmpScript.Name())
 	}()
-	_, _ = tmpScript.WriteString(fmt.Sprintf(`#!/bin/sh
-		echo $TMP_ENV>%s
-`, resultFile.Name()))
+	_, _ = fmt.Fprintf(tmpScript, "#!/bin/sh\n\t\techo $TMP_ENV>%s\n", resultFile.Name())
 	_ = tmpScript.Close()
 
 	rand := uuid.NewString()

--- a/pkg/fix_yaml_transform_test.go
+++ b/pkg/fix_yaml_transform_test.go
@@ -20,7 +20,7 @@ func (y *yamlTransformSuite) SetupTest() {
 }
 
 func (y *yamlTransformSuite) TearDownTest() {
-	y.testBase.teardown()
+	y.teardown()
 }
 
 func TestYamlTransformSuite(t *testing.T) {

--- a/pkg/grept_config_test.go
+++ b/pkg/grept_config_test.go
@@ -27,7 +27,7 @@ func (y *greptConfigSuite) SetupTest() {
 }
 
 func (y *greptConfigSuite) TearDownTest() {
-	y.testBase.teardown()
+	y.teardown()
 }
 
 func TestGreptConfigSuite(t *testing.T) {

--- a/pkg/grept_plan.go
+++ b/pkg/grept_plan.go
@@ -57,7 +57,7 @@ func (p *GreptPlan) String() string {
 		sb.WriteString("\n---\n")
 	}
 	for _, f := range p.Fixes {
-		sb.WriteString(fmt.Sprintf("%s would be apply:\n %s\n", f.Address(), golden.BlockToString(f)))
+		fmt.Fprintf(&sb, "%s would be apply:\n %s\n", f.Address(), golden.BlockToString(f))
 		sb.WriteString("\n---\n")
 	}
 


### PR DESCRIPTION
## What

Test upgrading golangci-lint from v1.64.8 to v2.10.1.

## Why

- v2 is the latest major version, built with the latest Go toolchain
- v2 removes the default timeout (no longer needs `--timeout` flag)
- This project has no `.golangci.yml` config file, so no migration should be needed

## Changes

- Docker image: `golangci/golangci-lint:v1.64.8` -> `golangci/golangci-lint:v2.10.1`
- Removed `--timeout=3600s` flag (v2 has no timeout by default)

Let's see if CI passes. If not, we stick with v1.64.8.